### PR TITLE
Enhance SEO for Faroese audience

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,20 +1,33 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fo">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vitlíkisstovan</title>
+    <title>Vitlíkisstovan - AI í Føroyum | ChatGPT skeið og verkstovur</title>
 
   <!-- Default Open Graph Meta Tags -->
-  <meta property="og:type" content="website">
-  <meta property="og:site_name" content="Ritvit">
-  <meta property="og:title" content="Ritvit - Tøkni Tænastan - Vitlíkisstovan">
-  <meta property="og:description" content="Vitlíkisstovan Webpage">
-  <meta property="og:image" content="https://ritvit.fo/images/podcast_thumbnail.png">
-  <meta property="og:url" content="https://ritvit.fo">
-  
-  <meta name="description" content="Vitlíkisstovan Webpage" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Vitlíkisstovan" />
+  <meta property="og:title" content="Vitlíkisstovan - AI í Føroyum" />
+  <meta property="og:description" content="ChatGPT skeið og vitlíki verkstovur til leiðarar og stjóra" />
+  <meta property="og:image" content="https://ritvit.fo/images/podcast_thumbnail.png" />
+  <meta property="og:url" content="https://ritvit.fo" />
+
+  <meta name="description" content="Vitlíkisstovan bjóðar AI ráðgeving, ChatGPT skeið og vitlíki verkstovur í Føroyum" />
+  <meta name="keywords" content="AI in the Faroe Islands, Vitlíki, ChatGPT skeið, ChatGPT course, Vitlíki verkstova" />
   <meta name="author" content="Gunnleygur Clementsen" />
+  <link rel="canonical" href="https://ritvit.fo" />
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Vitlíkisstovan",
+    "url": "https://ritvit.fo",
+    "logo": "https://ritvit.fo/images/podcast_thumbnail.png",
+    "description": "AI í Føroyum - ChatGPT skeið og vitlíki verkstovur"
+  }
+  </script>
   </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
+        "react-helmet": "^6.1.0",
         "react-hook-form": "^7.53.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^2.1.3",
@@ -8031,6 +8032,27 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.53.1",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.1.tgz",
@@ -8176,6 +8198,15 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-smooth": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
+    "react-helmet": "^6.1.0",
     "react-hook-form": "^7.53.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^2.1.3",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,7 +11,7 @@ const Footer = () => {
               <Link to="/" className="flex items-center">
                 <img
                   src="/logos/logo-header.png"
-                  alt="Logo"
+                  alt="Vitlíkisstovan logo"
                   className="h-10"
                   width="auto"
                   height="40"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -22,7 +22,7 @@ const Navigation = () => {
             <Link to="/" className="flex items-center gap-3">
               <img
                 src="/logos/logo-header.png"
-                alt="Logo"
+                alt="Vitlíkisstovan logo"
                 className="h-10"
                 width="auto"
                 height="40"

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,0 +1,56 @@
+import { Helmet } from "react-helmet";
+import {
+  defaultTitle,
+  defaultDescription,
+  defaultKeywords,
+  defaultImage,
+  siteUrl,
+  siteName,
+} from "@/lib/seo";
+
+interface SEOProps {
+  title?: string;
+  description?: string;
+  keywords?: string[];
+  image?: string;
+  url?: string;
+  structuredData?: Record<string, unknown>;
+}
+const SEO = ({
+  title = defaultTitle,
+  description = defaultDescription,
+  keywords = defaultKeywords,
+  image = defaultImage,
+  url = siteUrl,
+  structuredData,
+}: SEOProps) => {
+  const jsonLd = structuredData ? JSON.stringify(structuredData) : undefined;
+
+  return (
+    <Helmet>
+      <title>{title}</title>
+      {description && <meta name="description" content={description} />}
+      {keywords.length > 0 && (
+        <meta name="keywords" content={keywords.join(", ")} />
+      )}
+      <meta name="robots" content="index, follow" />
+      {url && <link rel="canonical" href={url} />}
+      <meta property="og:type" content="website" />
+      <meta property="og:locale" content="fo" />
+      <meta property="og:site_name" content={siteName} />
+      <meta property="og:title" content={title} />
+      {description && <meta property="og:description" content={description} />}
+      {image && <meta property="og:image" content={image} />}
+      {url && <meta property="og:url" content={url} />}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      {description && <meta name="twitter:description" content={description} />}
+      {image && <meta name="twitter:image" content={image} />}
+      {jsonLd && (
+        <script type="application/ld+json">{jsonLd}</script>
+      )}
+    </Helmet>
+  );
+};
+
+export default SEO;

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,19 @@
+export const defaultKeywords = [
+  "AI in the Faroe Islands",
+  "Vitlíki",
+  "ChatGPT skeið",
+  "ChatGPT course",
+  "Vitlíki verkstova",
+];
+
+export const defaultDescription =
+  "Vitlíkisstovan bjóðar AI ráðgeving, ChatGPT skeið og vitlíki verkstovur til føroyskar leiðarar og stjóra.";
+
+export const defaultTitle =
+  "Vitlíkisstovan - AI í Føroyum | ChatGPT skeið og verkstovur";
+
+export const defaultImage = "https://ritvit.fo/images/podcast_thumbnail.png";
+
+export const siteUrl = "https://ritvit.fo";
+
+export const siteName = "Vitlíkisstovan";

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,7 @@ import { ArrowRight, Mail, Phone, MessageSquare, CheckCircle2 } from "lucide-rea
 import { Link } from "react-router-dom";
 import { Input } from "@/components/ui/input";
 import GridBackground from "@/components/background/GridBackground";
+import SEO from "@/components/SEO";
 
 const Index = () => {
   const signupUrl = "https://docs.google.com/forms/d/e/1FAIpQLSfDtowxpOMTXaccvE49FM-e-LC9Hb6-pWO-E8Rr2jyOlgJnLg/viewform?usp=sf_link";
@@ -15,7 +16,13 @@ const openSignupForm = () => {
 };
 
   return (
-    <div className="min-h-screen flex flex-col bg-background text-text">
+    <>
+      <SEO
+        title="Vitlíkisstovan - AI í Føroyum | ChatGPT skeið og verkstovur"
+        description="Vitlíkisstovan bjóðar skeið í ChatGPT, vitlíki verkstovur og ráðgeving til føroyskar leiðarar og stjóra."
+        keywords={["AI in the Faroe Islands", "Vitlíki", "ChatGPT skeið", "ChatGPT course", "Vitlíki verkstova"]}
+      />
+      <div className="min-h-screen flex flex-col bg-background text-text">
       <Navigation />
 
       {/* Hero Section - Enhanced with Animations */}
@@ -74,7 +81,7 @@ const openSignupForm = () => {
                 <div className="absolute inset-0 bg-gradient-to-r from-primary/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-10"></div>
                 <img
                   src="/images/course-screenshot.png"
-                  alt="Course Screenshot"
+                  alt="Screenshot from our ChatGPT course for Faroese managers"
                   className="object-cover w-full h-full transition-transform duration-700 group-hover:scale-105"
                 />
               </div>
@@ -84,7 +91,7 @@ const openSignupForm = () => {
                   <div className="p-2 bg-background/50 rounded-full shadow-inner">
                     <img
                       src="/images/ChatGPT-Logo.webp"
-                      alt="OpenAI Logo"
+                      alt="OpenAI logo used in our ChatGPT course"
                       className="w-12 h-12 object-contain"
                     />
                   </div>
@@ -593,6 +600,7 @@ const openSignupForm = () => {
       <ChatbotButton />
       <Footer />
     </div>
+    </>
   );
 };
 

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -3,11 +3,19 @@ import { Button } from "@/components/ui/button";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import { Link } from "react-router-dom";
+import SEO from "@/components/SEO";
+import { siteUrl } from "@/lib/seo";
 
 export default function About() {
   return (
-    <div className="min-h-screen bg-background text-text">
-      <Navigation />
+    <>
+      <SEO
+        title="Um Vitlíkisstovuna - AI í Føroyum"
+        description="Kunnu teg um hvussu Vitlíkisstovan hjálpir leiðarum og stjóra at nýta vitlíki."
+        url={`${siteUrl}/about`}
+      />
+      <div className="min-h-screen bg-background text-text">
+        <Navigation />
 
       {/* Hero Section */}
       <section className="py-20">
@@ -172,5 +180,6 @@ export default function About() {
 
       <Footer />
     </div>
+    </>
   );
 }

--- a/src/pages/aboutCourse.tsx
+++ b/src/pages/aboutCourse.tsx
@@ -7,6 +7,8 @@ import Footer from "@/components/Footer";
 import ChatbotButton from "@/components/ChatbotButton";
 import { Button } from "@/components/ui/button";
 import { CheckCircle2 } from "lucide-react";
+import SEO from "@/components/SEO";
+import { siteUrl } from "@/lib/seo";
 
 
 /**
@@ -254,6 +256,12 @@ const AboutCourse: React.FC = () => {
   }, []);
 
   return (
+    <>
+      <SEO
+        title="ChatGPT skeið - Vitlíkisstovan"
+        description="Lær at brúka ChatGPT effektivt á føroyskum arbeiðsplássi."
+        url={`${siteUrl}/aboutCourse`}
+      />
     <div className="min-h-screen flex flex-col bg-background text-text">
       {/* Navigation */}
       <Navigation />
@@ -632,6 +640,7 @@ const AboutCourse: React.FC = () => {
       {/* Optional Chatbot floating button, if desired */}
       <ChatbotButton />
     </div>
+    </>
   );
 };
 

--- a/src/pages/betri-ai-podcast.tsx
+++ b/src/pages/betri-ai-podcast.tsx
@@ -5,6 +5,8 @@ import Footer from "@/components/Footer";
 import { Play, Pause, SkipBack, SkipForward } from "lucide-react";
 import MarkdownRenderer from "@/components/MarkdownRenderer";
 import { Button } from "@/components/ui/button";
+import SEO from "@/components/SEO";
+import { siteUrl } from "@/lib/seo";
 
 export default function BetriAIPodcast() {
   // Add Open Graph metadata for proper thumbnail
@@ -184,6 +186,12 @@ A short podcast about real world usecases for LLM tools throughout Betri.
   };
 
   return (
+    <>
+    <SEO
+      title="Betri AI Podcast - Vitlíkisstovan"
+      description="Hoyr hvussu Betri brúkar vitlíki í arbeiðinum."
+      url={`${siteUrl}/betri-ai-podcast`}
+    />
     <div className="min-h-screen bg-background text-text flex flex-col">
       <Navigation />
 
@@ -296,5 +304,6 @@ A short podcast about real world usecases for LLM tools throughout Betri.
 
       <Footer />
     </div>
+    </>
   );
 }

--- a/src/pages/birt.tsx
+++ b/src/pages/birt.tsx
@@ -8,6 +8,8 @@ import { Check, Copy, ChevronRight, ChevronLeft, Lock } from "lucide-react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { toast } from "sonner";
 import { Checkbox } from "@/components/ui/checkbox";
+import SEO from "@/components/SEO";
+import { siteUrl } from "@/lib/seo";
 
 // Define types for our prompts
 interface PromptTask {
@@ -237,6 +239,12 @@ const Birt = () => {
   }
 
   return (
+    <>
+      <SEO
+        title="Birt - Vitlíkisstovan"
+        description="Verkfærið Birt hjálpir tær at greina og deila tekst."
+        url={`${siteUrl}/birt`}
+      />
     <div className="min-h-screen flex flex-col bg-background text-text">
       <Navigation />
 
@@ -420,6 +428,7 @@ const Birt = () => {
 
       <Footer />
     </div>
+    </>
   );
 };
 

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -5,10 +5,14 @@ import { Button } from "@/components/ui/button";
 import { Calendar, Clock, ArrowLeft } from "lucide-react";
 import blogPosts from "@/data/blogPosts.json";
 import RelatedPosts from "@/components/blog/RelatedPosts";
+import SEO from "@/components/SEO";
+import { siteUrl, defaultDescription } from "@/lib/seo";
 
 const BlogPost = () => {
   const { id } = useParams();
   const post = blogPosts.find((post) => post.id === id);
+  const seoTitle = post ? `${post.title} - Vitlíkisstovan` : "Bloggur - Vitlíkisstovan";
+  const seoDescription = post?.excerpt ?? defaultDescription;
 
   if (!post) {
     return (
@@ -23,6 +27,13 @@ const BlogPost = () => {
   }
 
   return (
+    <>
+    <SEO
+      title={seoTitle}
+      description={seoDescription}
+      image={post?.imageUrl}
+      url={`${siteUrl}/blog/${id}`}
+    />
     <div className="min-h-screen flex flex-col bg-background text-text">
       <Navigation />
 
@@ -84,6 +95,7 @@ const BlogPost = () => {
 
       <Footer />
     </div>
+    </>
   );
 };
 

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -5,6 +5,8 @@ import BlogSearch from "@/components/blog/BlogSearch";
 import BlogCategories from "@/components/blog/BlogCategories";
 import BlogCard from "@/components/blog/BlogCard";
 import blogPosts from "@/data/blogPosts.json";
+import SEO from "@/components/SEO";
+import { siteUrl } from "@/lib/seo";
 
 const BlogIndex = () => {
   const [searchQuery, setSearchQuery] = useState("");
@@ -23,6 +25,12 @@ const BlogIndex = () => {
   });
 
   return (
+    <>
+      <SEO
+        title="Bloggur - Vitlíkisstovan"
+        description="Greinar um AI í Føroyum, vitlíki og ChatGPT."
+        url={`${siteUrl}/blog`}
+      />
     <div className="min-h-screen flex flex-col bg-background text-text">
       <Navigation />
 
@@ -80,6 +88,7 @@ const BlogIndex = () => {
 
       <Footer />
     </div>
+    </>
   );
 };
 

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -18,6 +18,8 @@ import { useToast } from "@/hooks/use-toast";
 import { Mail, MessageSquare, User } from "lucide-react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
+import { siteUrl } from "@/lib/seo";
 
 const formSchema = z.object({
   name: z.string().min(2, "Navnet skal være mindst 2 tegn"),
@@ -131,6 +133,12 @@ export default function Contact() {
   }
 
   return (
+    <>
+      <SEO
+        title="Samband - Vitlíkisstovan"
+        description="Set teg í samband við okkum fyri AI ráðgeving og skeið."
+        url={`${siteUrl}/contact`}
+      />
     <div className="min-h-screen bg-background text-text">
       <Navigation />
       <div className="py-20">
@@ -303,5 +311,6 @@ export default function Contact() {
       </div>
       <Footer />
     </div>
+    </>
   );
 }

--- a/src/pages/not-found.tsx
+++ b/src/pages/not-found.tsx
@@ -1,11 +1,19 @@
 import { Button } from "@/components/ui/button"
 import { useNavigate } from "react-router-dom"
 import { Home } from "lucide-react"
+import SEO from "@/components/SEO"
+import { siteUrl } from "@/lib/seo"
 
 export default function NotFound() {
   const navigate = useNavigate()
 
   return (
+    <>
+      <SEO
+        title="Síða ikki funnin - Vitlíkisstovan"
+        description="Síðan finst ikki."
+        url={`${siteUrl}/404`}
+      />
     <div className="min-h-screen flex items-center justify-center bg-background text-text">
       <div className="text-center animate-fade-up">
         <h1 className="text-6xl font-bold mb-4">404</h1>
@@ -17,5 +25,6 @@ export default function NotFound() {
         </Button>
       </div>
     </div>
+    </>
   )
 }

--- a/src/pages/risin-og-kellingin-podcast.tsx
+++ b/src/pages/risin-og-kellingin-podcast.tsx
@@ -5,6 +5,8 @@ import Footer from "@/components/Footer";
 import { Play, Pause, SkipBack, SkipForward } from "lucide-react";
 import MarkdownRenderer from "@/components/MarkdownRenderer";
 import { Button } from "@/components/ui/button";
+import SEO from "@/components/SEO";
+import { siteUrl } from "@/lib/seo";
 
 export default function RisinOgKellinginPodcast() {
   // Add Open Graph metadata for proper thumbnail
@@ -182,6 +184,12 @@ Risin og Kellingin podcast episoden udforsker legenden om Risin og Kellingin, to
   };
 
   return (
+    <>
+    <SEO
+      title="Risin og Kellingin Podcast - Vitlíkisstovan"
+      description="Frásøgan um risan og kellingina í AI podvarpi."
+      url={`${siteUrl}/risin_og_kellingin`}
+    />
     <div className="min-h-screen bg-background text-text flex flex-col">
       <Navigation />
 
@@ -292,5 +300,6 @@ Risin og Kellingin podcast episoden udforsker legenden om Risin og Kellingin, to
 
       <Footer />
     </div>
+    </>
   );
 }

--- a/src/pages/scenariotrainer.tsx
+++ b/src/pages/scenariotrainer.tsx
@@ -9,6 +9,8 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
+import { siteUrl } from "@/lib/seo";
 
 /**
  * ScenarioTrainer: A revolutionary platform that democratizes professional development.
@@ -18,6 +20,11 @@ import Footer from "@/components/Footer";
 const ScenarioTrainer: FC = () => {
   return (
     <>
+      <SEO
+        title="Scenario Trainer - Vitlíkisstovan"
+        description="AI-drivin venjingarskipan við realistiskum leiklutspæli."
+        url={`${siteUrl}/scenariotrainer`}
+      />
       <div className="bg-gradient-to-b from-background to-muted min-h-screen">
         {/* Hero Section */}
         <section className="pt-24 pb-16 px-4 container mx-auto text-center">

--- a/src/pages/services.tsx
+++ b/src/pages/services.tsx
@@ -11,9 +11,17 @@ import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
+import SEO from "@/components/SEO";
+import { siteUrl } from "@/lib/seo";
 
 export default function Services() {
   return (
+    <>
+      <SEO
+        title="Tænastur - Vitlíkisstovan"
+        description="AI ráðgeving og vitlíki verkstovur til føroyskar fyritøkur."
+        url={`${siteUrl}/services`}
+      />
     <div className="min-h-screen bg-background text-text">
       <Navigation />
       <div className="py-20">
@@ -250,5 +258,6 @@ export default function Services() {
       </div>
       <Footer />
     </div>
+    </>
   );
 }

--- a/src/pages/tariffs-podcast.tsx
+++ b/src/pages/tariffs-podcast.tsx
@@ -4,6 +4,8 @@ import Footer from "@/components/Footer";
 import { Play, Pause, SkipBack, SkipForward } from "lucide-react";
 import MarkdownRenderer from "@/components/MarkdownRenderer";
 import { Button } from "@/components/ui/button";
+import SEO from "@/components/SEO";
+import { siteUrl } from "@/lib/seo";
 
 export default function TariffsPodcast() {
   // Add Open Graph metadata for proper thumbnail
@@ -536,6 +538,12 @@ In conclusion, the U.S. tariffs, while undoubtedly challenging, can be a **catal
   };
 
   return (
+    <>
+    <SEO
+      title="Tariffs Podcast - Vitlíkisstovan"
+      description="Podvarpur um ávirkan av tollum á Føroyar."
+      url={`${siteUrl}/tariffs-podcast`}
+    />
     <div className="min-h-screen bg-background text-text flex flex-col">
       <Navigation />
 
@@ -647,5 +655,6 @@ In conclusion, the U.S. tariffs, while undoubtedly challenging, can be a **catal
 
       <Footer />
     </div>
+    </>
   );
 }

--- a/src/pages/tilarbeidis.tsx
+++ b/src/pages/tilarbeidis.tsx
@@ -1,4 +1,10 @@
-import { useState, useEffect } from "react";import { Calendar } from "lucide-react";import { Button } from "@/components/ui/button";import Navigation from "@/components/Navigation";import Footer from "@/components/Footer";
+import { useState, useEffect } from "react";
+import { Calendar } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import Navigation from "@/components/Navigation";
+import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
+import { siteUrl } from "@/lib/seo";
 
 
 
@@ -220,6 +226,12 @@ type TimelineEvent = {
 
   return (
 
+    <>
+    <SEO
+      title="Til arbeiðis - Vitlíkisstovan"
+      description="Arbeiðsdagur við vitlíki og effektivum verkfřrum."
+      url={`${siteUrl}/tilarbeidis`}
+    />
     <div className="min-h-screen bg-background text-text">
 
       <Navigation />
@@ -578,8 +590,9 @@ type TimelineEvent = {
 
       <Footer />
 
-    </div>
-
+  </div>
+    </>
   );
+};
 
-};export default Tilarbeidis;
+export default Tilarbeidis;

--- a/src/pages/vegleiding-laearar.tsx
+++ b/src/pages/vegleiding-laearar.tsx
@@ -1,5 +1,7 @@
 
 import { useEffect } from "react";
+import SEO from "@/components/SEO";
+import { siteUrl } from "@/lib/seo";
 
 const VegleidingLaearar = () => {
   useEffect(() => {
@@ -8,11 +10,18 @@ const VegleidingLaearar = () => {
   }, []);
 
   return (
+    <>
+      <SEO
+        title="Vegleiðing Lærarar - Vitlíkisstovan"
+        description="PDF vegleiðing til lærarar."
+        url={`${siteUrl}/vegleiding-laearar`}
+      />
     <div className="min-h-screen flex items-center justify-center bg-background text-text">
       <div className="text-center">
         <p className="text-lg">Redirecting to PDF...</p>
       </div>
     </div>
+    </>
   );
 };
 

--- a/src/process.d.ts
+++ b/src/process.d.ts
@@ -11,4 +11,4 @@ declare namespace NodeJS {
   }
 }
 
-declare var process: NodeJS.Process;
+declare let process: NodeJS.Process;


### PR DESCRIPTION
## Summary
- add SEO helper with Faroese keywords
- create `<SEO>` component with Open Graph and Twitter tags
- update index.html metadata
- embed SEO component across pages and improve image alt text
- fix lint issue in process declaration

## Testing
- `npm run lint` *(fails: 13 errors, 8 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687679fe2b1c8320bd1ce31ac3b059af